### PR TITLE
Update to work with Gnome shell 46

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -91,7 +91,7 @@ let SimpleMessage = GObject.registerClass({GTypeName: 'SimpleMessage'}, class Si
             y_align: Clutter.ActorAlign.CENTER,
             y_expand: true,
         });
-        this.add_actor(this.messageBox);
+        this.actor.add_child(this.messageBox);
 
         // Add message text
         this.messageBox.set_text(this.message);

--- a/metadata.json
+++ b/metadata.json
@@ -4,8 +4,8 @@
   "gettext-domain": "simple-message",
   "name": "Simple Message",
   "settings-schema": "org.gnome.shell.extensions.simple-message",
-  "shell-version": ["45"],
+  "shell-version": ["46"],
   "url": "https://github.com/freddez/gnome-shell-simple-message",
   "uuid": "simple-message@freddez",
-  "version": 15
+  "version": 16
 }


### PR DESCRIPTION
I'm not sure if different versions Gnome Shell Extensions can be made available to users. v15 for Gnome shell 45 users, and v16 for 46 users.

If not, we could add a version based check for the availability of `add_actor` method. 