### PR TITLE
Gnome 49: Fix by directly calling 'add_child' and declare 49 as supported

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -85,7 +85,9 @@ let SimpleMessage = GObject.registerClass(
         y_align: Clutter.ActorAlign.CENTER,
         y_expand: true,
       });
-      if (shellVersion >= 46) {
+      if (shellVersion >= 49) {
+        this.add_child(this.messageBox);
+      } else if (shellVersion >= 46) {
         this.actor.add_child(this.messageBox);
       } else {
         this.add_actor(this.messageBox);

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "gettext-domain": "simple-message",
   "name": "Simple Message",
   "settings-schema": "org.gnome.shell.extensions.simple-message",
-  "shell-version": ["45", "46", "47","48"],
+  "shell-version": ["45", "46", "47","48", "49"],
   "url": "https://github.com/freddez/gnome-shell-simple-message",
   "uuid": "simple-message@freddez",
   "version": 20


### PR DESCRIPTION
Hi,

I have recently updated to Gnome 49, and this extension failed to load. This fix seems to be working for me. Please consider this for the merge and publish on the Gnome Extensions.

Thanks!