### PR TITLE
Add font size configuration, fix name of the element in css

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -76,6 +76,7 @@ let SimpleMessage = GObject.registerClass(
       this._settings = extensionObject.getSettings();
       this.message = this._settings.get_string("message");
       this.command = this._settings.get_string("command");
+      this.font_size = this._settings.get_string("font-size");
       this.message_alignment = this._settings.get_int("panel-alignment");
       this.message_position = this._settings.get_int("panel-position");
 
@@ -95,6 +96,7 @@ let SimpleMessage = GObject.registerClass(
 
       // Add message text
       this.messageBox.set_text(this.message);
+      this.messageBox.set_style("font-size: " + this.font_size + ";");
       // Add message to panel
       Main.panel.addToStatusArea(
         "simpleMessage",
@@ -111,6 +113,10 @@ let SimpleMessage = GObject.registerClass(
       this._settings.connect(
         "changed::command",
         this._rewriteCommand.bind(this),
+      );
+      this._settings.connect(
+        "changed::font-size",
+        this._rewriteFontsize.bind(this),
       );
       this._settings.connect(
         "changed::panel-alignment",
@@ -151,6 +157,10 @@ let SimpleMessage = GObject.registerClass(
     }
     _rewriteCommand() {
       this.command = this._settings.get_string("command");
+    }
+    _rewriteFontsize() {
+      this.font_size = this._settings.get_string("font-size");
+      this.messageBox.set_style("font-size: " + this.font_size + ";");
     }
   },
 );

--- a/prefs.js
+++ b/prefs.js
@@ -126,6 +126,28 @@ export default class SimpleMessahePreferences extends ExtensionPreferences {
     })
     // Add the text box to the row
     commandRow.add_suffix(commandField);
+
+
+    // Create an option to configure message box font size
+    const fontsizeRow = new Adw.ActionRow({
+        title: 'Font Size',
+        subtitle: 'Confirm with Enter'
+    });
+    group.add(fontsizeRow);
+    const fontsizeText = new Gtk.EntryBuffer({
+        text: window.settings.get_string('font-size')
+    });
+    const fontsizeField = new Gtk.Entry({
+        buffer: fontsizeText,
+        hexpand: true,
+        valign:Gtk.Align.CENTER,
+        halign:Gtk.Align.CENTER
+    })
+    fontsizeField.connect('activate', () => {
+      window.settings.set_string('font-size', fontsizeText.text);
+    })
+    // Add the text box to the row
+    fontsizeRow.add_suffix(fontsizeField);
   }
 }
 

--- a/schemas/org.gnome.shell.extensions.simple-message.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.simple-message.gschema.xml
@@ -21,5 +21,10 @@
             <summary>Command</summary>
             <description>Command to launch on click</description>
         </key>
+        <key name="font-size" type="s">
+            <default>"100%"</default>
+            <summary>Font size</summary>
+            <description>Size of the font message</description>
+        </key>
     </schema>
 </schemalist>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,4 +1,4 @@
-#simple-message-new-message {
+#simple-message-message {
 	margin:  0.2em 0.4em;
 	padding: 0.2em;
 }


### PR DESCRIPTION
Change 4ac4e8acce6bbaadca1d50324c1f7c3cea863b66

I am using simple message extension to print two lines when emacs displays something. However at 100% font size, it doesn't fit nicely, so I had to modify the extension CSS to configure font size to my liking. See an example (font size = 65%):

<img width="1029" height="143" alt="image" src="https://github.com/user-attachments/assets/b7be7ddc-bfe0-44b3-b76a-0918b5563e1b" />

With this change, font size can be configurable. I have chosen string type for this, so that users can specify font size in any way they like: pixel size, in percentage, or any other way. No input validation though.

Change 051aea72b4f4f6710163a73136a3cf6dfb23561e

As I have noticed, label element is no longer 'simple-message-new-message', but 'simple-message-message'. Haven't noticed much difference though with applying this 